### PR TITLE
Update invoke syntax

### DIFF
--- a/{{cookiecutter.script_name}}/tasks.py
+++ b/{{cookiecutter.script_name}}/tasks.py
@@ -6,40 +6,47 @@ from invoke import task, run
 docs_dir = 'docs'
 build_dir = os.path.join(docs_dir, '_build')
 
-@task
-def test():
-    run('python setup.py test', pty=True)
 
 @task
-def clean():
+def test(ctx):
+    run('python setup.py test', pty=True)
+
+
+@task
+def clean(ctx):
     run("rm -rf build")
     run("rm -rf dist")
     run("rm -rf {{cookiecutter.repo_name}}.egg-info")
-    clean_docs()
+    clean_docs(ctx)
     print("Cleaned up.")
 
+
 @task
-def clean_docs():
+def clean_docs(ctx):
     run("rm -rf %s" % build_dir)
 
+
 @task
-def browse_docs():
+def browse_docs(ctx):
     run("open %s" % os.path.join(build_dir, 'index.html'))
 
+
 @task
-def build_docs(clean=False, browse=False):
+def build_docs(ctx, clean=False, browse=False):
     if clean:
-        clean_docs()
+        clean_docs(ctx)
     run("sphinx-build %s %s" % (docs_dir, build_dir), pty=True)
     if browse:
-        browse_docs()
+        browse_docs(ctx)
+
 
 @task
-def readme(browse=False):
+def readme(ctx, browse=False):
     run('rst2html.py README.rst > README.html')
 
+
 @task
-def publish(test=False):
+def publish(ctx, test=False):
     """Publish to the cheeseshop."""
     if test:
         run('python setup.py register -r test sdist upload -r test')

--- a/{{cookiecutter.script_name}}/tasks.py
+++ b/{{cookiecutter.script_name}}/tasks.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 
 from invoke import task, run
 


### PR DESCRIPTION
Hi cloria, since 0.13.0, `invoke` requires all task must be contextualized, [see more](http://www.pyinvoke.org/changelog.html). This PR tends to fix that.

>[Feature] #114: Ripped off the band-aid and removed non-contextualized tasks as an option; all tasks must now be contextualized (defined as def mytask(context, ...) - see Defining and running task functions) even if not using the context. This simplifies the implementation as well as users’ conceptual models. Thanks to Bay Grabowski for the patch.

Please let me know if you need any modification. Thanks.